### PR TITLE
csl-TESTCompleteOrder

### DIFF
--- a/bangazon_api/views/order_view.py
+++ b/bangazon_api/views/order_view.py
@@ -67,6 +67,7 @@ class OrderView(ViewSet):
                 pk=request.data['paymentTypeId'], customer=request.auth.user)
             order.payment_type = payment_type
             order.completed_on = datetime.now()
+            order.save()
             return Response({'message': "Order Completed"}, status=status.HTTP_204_NO_CONTENT)
         except (Order.DoesNotExist, PaymentType.DoesNotExist) as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -37,10 +37,8 @@ class OrderTests(APITestCase):
         self.client.credentials(
             HTTP_AUTHORIZATION=f'Token {self.token.key}')
 
-        self.payment_type_id = PaymentType.objects.create(
-            merchant_name = "VISA 16 digit",
-            acct_number = 	6759504019261234,
-            customer_id = 1
+        self.payment_type1 = PaymentType.objects.create(
+            customer=self.user1
         )
         
     def test_list_orders(self):
@@ -62,12 +60,13 @@ class OrderTests(APITestCase):
         """make sure you can complete an order
         """
         data = {
-            "paymentTypeId": self.payment_type_id.id
+            "paymentTypeId": self.payment_type1.id
             
         }
         
         response = self.client.put(f'/api/orders/{self.order1.id}/complete', data, format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         order = Order.objects.get(pk = self.order1.id)
+        print(order)
         self.assertEqual(order.payment_type_id, data['paymentTypeId'])
         self.assertIsNotNone(order.completed_on)


### PR DESCRIPTION
Issue #13 Complete Order by Adding Payment type Test

Re-added the .save() in the complete custom action in the  OrderView that must have gotten lost somewhere in my edits and pushing and pulling. That was the reason why it was causing the assertion error I was getting. 

Created test_complete_order in test_order.py previously 
Simplified the creation of the payment type using self in setUp 